### PR TITLE
Config setting for custom client certificates

### DIFF
--- a/nmostesting/Config.py
+++ b/nmostesting/Config.py
@@ -104,6 +104,9 @@ KEYS_MOCKS = [
     "test_data/BCP00301/ca/intermediate/private/rsa.mocks.testsuite.nmos.tv.key.pem"
 ]
 
+# Combined certificate and key. Client side.
+CERT_CLIENT = "example/path/to/client/cert.pem"
+
 # Test using authorization as per AMWA IS-10 and BCP-003-02
 ENABLE_AUTH = False
 

--- a/nmostesting/TestHelper.py
+++ b/nmostesting/TestHelper.py
@@ -199,7 +199,7 @@ def do_request(method, url, headers=None, **kwargs):
 
         req = requests.Request(method, url, headers={k: v for k, v in headers.items() if v is not None}, **kwargs)
         prepped = s.prepare_request(req)
-        settings = s.merge_environment_settings(prepped.url, {}, None, CONFIG.CERT_TRUST_ROOT_CA, None)
+        settings = s.merge_environment_settings(prepped.url, {}, None, CONFIG.CERT_TRUST_ROOT_CA, CONFIG.CERT_CLIENT)
         response = s.send(prepped, timeout=CONFIG.HTTP_TIMEOUT, **settings)
         if prepped.url.startswith("https://"):
             if not response.url.startswith("https://"):


### PR DESCRIPTION
Configured with `CONFIG.CERT_CLIENT` in `UserConfig.py`. Can be either tuple (cert path, key path) or just a string for the path to the combined certificate.