### PR TITLE
Fix: mocked registries can have different protocol

### DIFF
--- a/nmostesting/Config.py
+++ b/nmostesting/Config.py
@@ -81,6 +81,9 @@ MAX_TEST_ITERATIONS = 0
 # Test using HTTPS rather than HTTP as per AMWA BCP-003-01
 ENABLE_HTTPS = False
 
+# Test mocked registries using HTTPS rather than HTTPS (beneficial to se tto false in order to avoid mTLS cert headaches)
+ENABLE_REGISTRY_MOCK_HTTPS = False
+
 # Prefer a specific network interface when making mDNS announcements and similar.
 # Example: BIND_INTERFACE = 'ens1f0'
 BIND_INTERFACE = None

--- a/nmostesting/Config.py
+++ b/nmostesting/Config.py
@@ -81,7 +81,7 @@ MAX_TEST_ITERATIONS = 0
 # Test using HTTPS rather than HTTP as per AMWA BCP-003-01
 ENABLE_HTTPS = False
 
-# Test mocked registries using HTTPS rather than HTTPS (beneficial to se tto false in order to avoid mTLS cert headaches)
+# Test mocked registries using HTTPS rather than HTTPS (beneficial to set to false in order to avoid mTLS cert headaches)
 ENABLE_REGISTRY_MOCK_HTTPS = False
 
 # Prefer a specific network interface when making mDNS announcements and similar.

--- a/nmostesting/ControllerTest.py
+++ b/nmostesting/ControllerTest.py
@@ -124,9 +124,9 @@ class ControllerTest(GenericTest):
         self.primary_registry.enable()
 
         host = get_mocks_hostname() if CONFIG.ENABLE_HTTPS else get_default_ip()
-        self.mock_registry_base_url = self.protocol + '://' + host + ':'\
+        self.mock_registry_base_url = self.mock_registry_protocol + '://' + host + ':'\
             + str(self.primary_registry.get_data().port) + '/'
-        self.mock_node_base_url = self.protocol + '://' + host + ':' + str(self.node.port) + '/'
+        self.mock_node_base_url = self.mock_registry_protocol + '://' + host + ':' + str(self.node.port) + '/'
 
         # Populate mock registry with senders and receivers and store the results
         try:

--- a/nmostesting/GenericTest.py
+++ b/nmostesting/GenericTest.py
@@ -70,10 +70,13 @@ class GenericTest(object):
         self.test_individual = False
         self.result = list()
         self.protocol = "http"
+        self.mock_registry_protocol = "http"
         self.ws_protocol = "ws"
         if CONFIG.ENABLE_HTTPS:
             self.protocol = "https"
             self.ws_protocol = "wss"
+        if CONFIG.ENABLE_REGISTRY_MOCK_HTTPS:
+            self.mock_registry_protocol = "https"
         self.authorization = False
         if CONFIG.ENABLE_AUTH:
             self.authorization = True

--- a/nmostesting/NMOSTesting.py
+++ b/nmostesting/NMOSTesting.py
@@ -124,7 +124,7 @@ for instance in range(NUM_REGISTRIES):
     reg_app.debug = False
     reg_app.config['REGISTRY_INSTANCE'] = instance
     reg_app.config['PORT'] = REGISTRIES[instance].port
-    reg_app.config['SECURE'] = CONFIG.ENABLE_REGISTRY_HTTPS
+    reg_app.config['SECURE'] = CONFIG.ENABLE_REGISTRY_MOCK_HTTPS
     reg_app.register_blueprint(REGISTRY_API)  # Dependency for IS0401Test
     FLASK_APPS.append(reg_app)
 
@@ -980,7 +980,7 @@ def check_internal_requirements():
     if platform.system() == "Windows":
         print("Skipping internal requirements skip on windows")
         return
-    
+
     corrections = {"gitpython": "git",
                    "pyopenssl": "OpenSSL",
                    "websocket-client": "websocket",

--- a/nmostesting/NMOSTesting.py
+++ b/nmostesting/NMOSTesting.py
@@ -124,7 +124,7 @@ for instance in range(NUM_REGISTRIES):
     reg_app.debug = False
     reg_app.config['REGISTRY_INSTANCE'] = instance
     reg_app.config['PORT'] = REGISTRIES[instance].port
-    reg_app.config['SECURE'] = CONFIG.ENABLE_HTTPS
+    reg_app.config['SECURE'] = CONFIG.ENABLE_REGISTRY_HTTPS
     reg_app.register_blueprint(REGISTRY_API)  # Dependency for IS0401Test
     FLASK_APPS.append(reg_app)
 

--- a/nmostesting/suites/IS0401Test.py
+++ b/nmostesting/suites/IS0401Test.py
@@ -128,6 +128,9 @@ class IS0401Test(GenericTest):
         service_type = "_nmos-registration._tcp.local."
         if self.is04_utils.compare_api_version(self.apis[NODE_API_KEY]["version"], "v1.3") >= 0:
             service_type = "_nmos-register._tcp.local."
+            
+        if api_proto is None:
+            api_proto = self.mock_registry_protocol
 
         txt = {'pri': str(priority)}
 


### PR DESCRIPTION
### Context

ticket: https://dev.azure.com/BrainlabAG-Ext/VIED-Ext/_workitems/edit/2569

We currently have an issue with the nmos-testing tool and UpHIL. The nmos-testing tool can currently never pass because we NEED to enable HTTPS to communicate with the Quip (node-API only reachable through envoy), but also we dont have the supporting certificates for the mocked registries being spun up by the testing tool. 
Originally the idea was to maybe create multiple certificates for the nmot-testing-tool-registries, but that would require big patches to the tool itself and some effort to generate them.

I now propose to just turn off security from the node to the registry, since this is not relevant to what we are trying to test.

I added an additional config item that lets users specify whether or not the mocked registries should be using HTTPS or HTTP.

This will probably not magically fix the tests on UpHIL, but it might :)

### Changes
- Added config item `ENABLE_REGISTRY_MOCK_HTTPS`
- Dragged the config value through the python inheritance chain and used it to set relevant registry flags 